### PR TITLE
Add basic orthodontics website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
-# test-page
+# Cabinet d'Orthodontie
+
+Site statique pour un cabinet d'orthodontie, conçu pour être déployé avec GitHub Pages.
+
+Ouvrez `index.html` dans un navigateur pour voir la page.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Cabinet d'Orthodontie</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <header>
+    <h1>Cabinet d'Orthodontie</h1>
+    <nav>
+      <a href="#about">À propos</a>
+      <a href="#services">Services</a>
+      <a href="#contact">Contact</a>
+    </nav>
+  </header>
+
+  <section id="about">
+    <h2>À propos</h2>
+    <p>Notre cabinet d'orthodontie propose des soins personnalisés pour tous les âges.</p>
+  </section>
+
+  <section id="services">
+    <h2>Services</h2>
+    <ul>
+      <li>Appareils dentaires</li>
+      <li>Orthodontie invisible</li>
+      <li>Suivi pédiatrique</li>
+    </ul>
+  </section>
+
+  <section id="contact">
+    <h2>Contact</h2>
+    <p>Adresse : 123 Rue du Sourire, 75000 Paris</p>
+    <p>Téléphone : 01 23 45 67 89</p>
+    <p>Email : <a href="mailto:contact@cabinet-ortho.fr">contact@cabinet-ortho.fr</a></p>
+  </section>
+
+  <footer>
+    <p>&copy; 2025 Cabinet d'Orthodontie</p>
+  </footer>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,30 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+  line-height: 1.6;
+}
+
+header {
+  background: #3f51b5;
+  color: #fff;
+  padding: 1rem 0;
+  text-align: center;
+}
+
+nav a {
+  color: #fff;
+  margin: 0 1rem;
+  text-decoration: none;
+}
+
+section {
+  padding: 1rem;
+}
+
+footer {
+  background: #f4f4f4;
+  text-align: center;
+  padding: 1rem;
+  font-size: 0.9rem;
+}


### PR DESCRIPTION
## Summary
- add static site for orthodontics practice with about, services, and contact sections
- style the page with simple CSS
- document site usage in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c19736c06483258fbd11e8b9309f68